### PR TITLE
Add ddn confusion matrix library

### DIFF
--- a/ddn/CMakeLists.txt
+++ b/ddn/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.14)
+project(ddn LANGUAGES C)
+
+# Library for confusion matrix
+add_library(ddn_confusion STATIC
+    src/confusion_matrix.c
+)
+
+target_include_directories(ddn_confusion PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+# Test executable
+add_executable(test_confusion_matrix
+    tests/test_confusion_matrix.c
+)
+
+target_link_libraries(test_confusion_matrix ddn_confusion)
+
+enable_testing()
+add_test(NAME ConfusionMatrixTest COMMAND test_confusion_matrix)

--- a/ddn/Makefile
+++ b/ddn/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all build test clean
+
+BUILD_DIR := build
+
+all: build
+
+build:
+	cmake -S . -B $(BUILD_DIR)
+	cmake --build $(BUILD_DIR)
+
+test:
+	cmake --build $(BUILD_DIR) --target test
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/ddn/cmake/Config.cmake
+++ b/ddn/cmake/Config.cmake
@@ -1,0 +1,2 @@
+# Placeholder for project-specific CMake modules
+# This file can be extended with custom functions

--- a/ddn/include/confusion_matrix.h
+++ b/ddn/include/confusion_matrix.h
@@ -1,0 +1,30 @@
+#ifndef DDN_CONFUSION_MATRIX_H
+#define DDN_CONFUSION_MATRIX_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Classification labels for QA metrics
+typedef enum {
+    DDN_TRUE_POSITIVE = 0,
+    DDN_TRUE_NEGATIVE = 1,
+    DDN_FALSE_POSITIVE = 2,
+    DDN_FALSE_NEGATIVE = 3
+} ddn_label_t;
+
+typedef struct {
+    uint32_t counts[4];
+} ddn_confusion_matrix_t;
+
+void ddn_cm_init(ddn_confusion_matrix_t* cm);
+void ddn_cm_update(ddn_confusion_matrix_t* cm, ddn_label_t label);
+uint32_t ddn_cm_get(const ddn_confusion_matrix_t* cm, ddn_label_t label);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DDN_CONFUSION_MATRIX_H

--- a/ddn/src/confusion_matrix.c
+++ b/ddn/src/confusion_matrix.c
@@ -1,0 +1,17 @@
+#include "confusion_matrix.h"
+#include <string.h>
+
+void ddn_cm_init(ddn_confusion_matrix_t* cm) {
+    if (!cm) return;
+    memset(cm, 0, sizeof(*cm));
+}
+
+void ddn_cm_update(ddn_confusion_matrix_t* cm, ddn_label_t label) {
+    if (!cm || label < 0 || label > 3) return;
+    cm->counts[label]++;
+}
+
+uint32_t ddn_cm_get(const ddn_confusion_matrix_t* cm, ddn_label_t label) {
+    if (!cm || label < 0 || label > 3) return 0;
+    return cm->counts[label];
+}

--- a/ddn/tests/test_confusion_matrix.c
+++ b/ddn/tests/test_confusion_matrix.c
@@ -1,0 +1,21 @@
+#include "confusion_matrix.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    ddn_confusion_matrix_t cm;
+    ddn_cm_init(&cm);
+
+    ddn_cm_update(&cm, DDN_TRUE_POSITIVE);
+    ddn_cm_update(&cm, DDN_TRUE_NEGATIVE);
+    ddn_cm_update(&cm, DDN_FALSE_POSITIVE);
+    ddn_cm_update(&cm, DDN_FALSE_NEGATIVE);
+
+    assert(ddn_cm_get(&cm, DDN_TRUE_POSITIVE) == 1);
+    assert(ddn_cm_get(&cm, DDN_TRUE_NEGATIVE) == 1);
+    assert(ddn_cm_get(&cm, DDN_FALSE_POSITIVE) == 1);
+    assert(ddn_cm_get(&cm, DDN_FALSE_NEGATIVE) == 1);
+
+    printf("Confusion matrix tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a `ddn` component with CMake build
- implement `confusion_matrix` library exposing true/false positive/negative metrics
- include a small test and Makefile

## Testing
- `cd ddn && make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6861729d133883279f0ff05717aaf5f2